### PR TITLE
Improve alignment of text nodes in make-cd

### DIFF
--- a/TeXmacs/progs/graphics/graphics-main.scm
+++ b/TeXmacs/progs/graphics/graphics-main.scm
@@ -291,6 +291,7 @@
     (:idle 1)
     (graphics-set-extents "8.1cm" "3.1cm")
     (graphics-set-text-at-halign "center")
+    (graphics-set-text-at-valign "center")
     (graphics-set-arrow-end "<gtr>")
     (graphics-set-mode '(edit math-at))
     (graphics-set-notebook-grid)))


### PR DESCRIPTION
Currently text nodes in a commutative diagram are vertically aligned on their baseline. This is an intuitive and reasonable default, but unfortunately it results in incorrect behavior when combined with snapping; in particular, there are many cases (depending on the physical height of a piece of math text) where drawing an fully horizontal or fully vertical arrow from one math node to another is impossible to achieve with precision, and instead it snaps to something that is at a strange angle. This problem is solved by setting the vertical alignment to be centered.

I am not sure that this is the actual best solution, but it solved the immediate problem for me. What do you think?

**P.S. I have not yet succeeded in building TeXmacs on my machine, so I have just edited this code blindly --- so please don't merge unless you try it out. The way I tested this functionality was to create a new function in my own TeXmacs initialization script and add my own custom menu item for the new function.**